### PR TITLE
added forbid proptypes react rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   "semi": [
       1,
       "never"
-  ]
+  ],
+  "react/forbid-prop-types": [2]
   },
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended"],
   "plugins": [ "react", "jest" ],


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md

Enforces more specific PropTypes so you can't just use e.g. `PropTypes.object` or `PropTypes.array` without defining what goes in them (i.e. by using `PropTypes.shape({})` or `PropTypes.arrayOf()`