### PR TITLE
added require default props

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   "semi": [
       1,
       "never"
-  ]
+  ],
+  "react/require-default-props": [2]
   },
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended"],
   "plugins": [ "react", "jest" ],


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md

Means if a PropType is not `.isRequired`, then you have to provide a `defaultProp`.