### PR TITLE
added destructuring rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   "semi": [
       1,
       "never"
-  ]
+  ],
+  "react/destructuring-assignment": [2, "always"]
   },
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended"],
   "plugins": [ "react", "jest" ],


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md

Enforces destructuring of `props`, `state` and `context` to avoid repetition all over components. So this:
`this.props.blah` has to become `const { blah } = this.props`