### PR TITLE
enforce no unused propTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   "semi": [
       1,
       "never"
-  ]
+  ],
+  "react/no-unused-prop-types": [2] 
   },
   "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended"],
   "plugins": [ "react", "jest" ],


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md

Warns you when propTypes are defined that are no longer used.